### PR TITLE
chore(templates): align Fluxzero SDK with MCP docs

### DIFF
--- a/flux-basic-java/build.gradle.kts
+++ b/flux-basic-java/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 group = "com.example"
 version = "0.0.1-SNAPSHOT"
 
-val fluxzeroVersion = "1.215.5"
+val fluxzeroVersion = "1.215.6"
 val fluxzeroIdpVersion = "0.13.0"
 val jettyVersion = "12.1.11"
 val lombokVersion = "1.18.46"

--- a/flux-basic-java/pom.xml
+++ b/flux-basic-java/pom.xml
@@ -21,7 +21,7 @@
 			<dependency>
 				<groupId>io.fluxzero</groupId>
 				<artifactId>fluxzero-bom</artifactId>
-				<version>1.215.5</version>
+				<version>1.215.6</version>
 				<scope>import</scope>
 				<type>pom</type>
 			</dependency>

--- a/flux-basic-kotlin/build.gradle.kts
+++ b/flux-basic-kotlin/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 group = "com.example.flux"
 version = "1.0-SNAPSHOT"
 
-val fluxzeroVersion = "1.215.5"
+val fluxzeroVersion = "1.215.6"
 val fluxzeroIdpVersion = "0.13.0"
 
 repositories {

--- a/flux-basic-kotlin/pom.xml
+++ b/flux-basic-kotlin/pom.xml
@@ -16,7 +16,7 @@
         <kotlin-logging.version>7.0.14</kotlin-logging.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <fluxzero.version>1.215.5</fluxzero.version>
+        <fluxzero.version>1.215.6</fluxzero.version>
         <fluxzero-idp.version>0.13.0</fluxzero-idp.version>
     </properties>
 


### PR DESCRIPTION
## Summary

- align both Java and Kotlin starters with the Fluxzero SDK version advertised by the production MCP documentation
- update the Maven and Gradle declarations together so generated projects do not require an immediate SDK upgrade

## Verification

- `flux-basic-java/./mvnw -q test`
- `flux-basic-java/./gradlew --no-daemon test`
- `flux-basic-kotlin/./mvnw -q test`
- `flux-basic-kotlin/./gradlew --no-daemon test`
- packaged both templates and verified SDK `1.215.6` is present with no Game Rental, `CLAUDE.md`, or `.fluxzero/agents` content

The Maven and Gradle project-file synchronization plugins remain unchanged; this PR only aligns the starter dependency versions.
