### PR TITLE
Bootstrap Fluxzero integrations for multiple coding agents

### DIFF
--- a/.github/scripts/package-templates.sh
+++ b/.github/scripts/package-templates.sh
@@ -7,18 +7,23 @@ staging=$(mktemp -d)
 trap 'rm -rf "$staging"' EXIT
 
 templates=(flux-basic-java flux-basic-kotlin)
-[[ ! -e "$repo_root/CLAUDE.md" ]] || {
-  echo "Root CLAUDE.md is reserved for a future Claude-compatible Fluxzero integration" >&2
-  exit 1
-}
+project_instructions=(AGENTS.md CLAUDE.md GEMINI.md)
+
+for instruction in "${project_instructions[@]}"; do
+  [[ -f "$repo_root/$instruction" ]] || { echo "Missing root $instruction" >&2; exit 1; }
+done
+
 for template in "${templates[@]}"; do
   source_dir="$repo_root/$template"
   [[ -d "$source_dir" ]] || { echo "Missing template: $template" >&2; exit 1; }
-  [[ -f "$source_dir/AGENTS.md" ]] || { echo "Missing $template/AGENTS.md" >&2; exit 1; }
-  [[ ! -e "$source_dir/CLAUDE.md" ]] || {
-    echo "$template/CLAUDE.md is reserved for a future Claude-compatible Fluxzero integration" >&2
-    exit 1
-  }
+
+  for instruction in "${project_instructions[@]}"; do
+    [[ -f "$source_dir/$instruction" ]] || { echo "Missing $template/$instruction" >&2; exit 1; }
+    cmp -s "$repo_root/$instruction" "$source_dir/$instruction" || {
+      echo "$template/$instruction differs from the reviewed root instruction" >&2
+      exit 1
+    }
+  done
 
   if find "$source_dir" -path '*/.fluxzero/agents*' -print -quit | grep -q .; then
     echo "Repository-local Fluxzero manuals are not allowed in template $template" >&2

--- a/.github/scripts/verify-templates.sh
+++ b/.github/scripts/verify-templates.sh
@@ -114,7 +114,7 @@ main() {
         # Check for expected files
         cd "$project_name"
         
-        expected_files=("src" "gradlew" "AGENTS.md")
+        expected_files=("src" "gradlew" "AGENTS.md" "CLAUDE.md" "GEMINI.md")
         for file in "${expected_files[@]}"; do
             if [ -e "$file" ]; then
                 log_success "Found expected file/directory: $file"
@@ -123,10 +123,12 @@ main() {
             fi
         done
 
-        if [ -e "CLAUDE.md" ]; then
-            log_error "CLAUDE.md must not be generated before a Claude-compatible Fluxzero integration exists"
-            exit 1
-        fi
+        for instruction in AGENTS.md CLAUDE.md GEMINI.md; do
+            if ! cmp -s "$REPO_ROOT/$instruction" "$instruction"; then
+                log_error "Generated $instruction differs from the reviewed template instruction"
+                exit 1
+            fi
+        done
 
         # Check for build file (either Gradle or Maven)
         if [ -f "build.gradle.kts" ] || [ -f "build.gradle" ]; then

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,7 @@
 # Fluxzero Agent Instructions
 
-Use the installed Fluxzero plugin for all Fluxzero framework work in this repository. Retrieve current SDK guidance
-through the plugin's Fluxzero MCP server; do not add or rely on repository-local Fluxzero manuals.
+Use the installed Fluxzero integration for all Fluxzero application work in this project. Retrieve current SDK guidance through its Fluxzero MCP server and follow the `build-fluxzero-app` skill.
+
+If that skill or MCP server is unavailable, install the Fluxzero integration for the coding agent you are currently running from `fluxzero-io/fluxzero-agent-integrations`. Installation changes agent startup configuration, so stop after installation and ask the user to reload the agent or start a new session before changing Fluxzero code.
+
+Use the integration as the single documentation source; do not add repository-local Fluxzero manuals or duplicate the Fluxzero MCP configuration in this project.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,12 @@
+@AGENTS.md
+
+## Claude Code bootstrap
+
+If the Fluxzero plugin is unavailable, run:
+
+```bash
+claude plugin marketplace add fluxzero-io/fluxzero-agent-integrations
+claude plugin install fluxzero@fluxzero
+```
+
+Then run `/reload-plugins` or start a new Claude Code session before continuing.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,11 @@
+@./AGENTS.md
+
+## Gemini CLI bootstrap
+
+If the Fluxzero extension is unavailable, run this from a terminal outside the current interactive session:
+
+```bash
+gemini extensions install https://github.com/fluxzero-io/fluxzero-agent-integrations --consent
+```
+
+Then restart Gemini CLI before continuing.

--- a/README.md
+++ b/README.md
@@ -20,8 +20,14 @@ fz init --template flux-basic-java --name my-app --package com.example.myapp --b
 
 Use `flux-basic-kotlin` for a Kotlin project and choose either `maven` or `gradle` for `--build`.
 
-Generated projects do not contain local Fluxzero SDK manuals. Their small agent instruction file directs coding agents
-to the installed Fluxzero plugin, which supplies the application-building workflow and current MCP documentation.
+Generated projects do not contain local Fluxzero SDK manuals. Their small agent instruction files direct Codex,
+Claude Code, Cursor, Gemini CLI, or GitHub Copilot to the matching adapter in
+[`fluxzero-agent-integrations`](https://github.com/fluxzero-io/fluxzero-agent-integrations), which supplies the shared
+application-building skill and current MCP documentation.
+
+`AGENTS.md` contains the shared rule used by Codex, Cursor, and GitHub Copilot. `CLAUDE.md` and `GEMINI.md` import that
+rule and add only the bootstrap command and reload boundary required by their own clients. The integration remains an
+agent-level installation and is not copied into generated projects, so the Fluxzero MCP server is registered only once.
 
 ## Validate templates
 

--- a/flux-basic-java/AGENTS.md
+++ b/flux-basic-java/AGENTS.md
@@ -1,5 +1,7 @@
 # Fluxzero Agent Instructions
 
-Use the installed Fluxzero plugin for all Fluxzero application work in this project. Retrieve current SDK guidance
-through the plugin's Fluxzero MCP server; do not add or rely on repository-local Fluxzero manuals. If the plugin is not
-available, stop and ask the user to install it before changing Fluxzero code.
+Use the installed Fluxzero integration for all Fluxzero application work in this project. Retrieve current SDK guidance through its Fluxzero MCP server and follow the `build-fluxzero-app` skill.
+
+If that skill or MCP server is unavailable, install the Fluxzero integration for the coding agent you are currently running from `fluxzero-io/fluxzero-agent-integrations`. Installation changes agent startup configuration, so stop after installation and ask the user to reload the agent or start a new session before changing Fluxzero code.
+
+Use the integration as the single documentation source; do not add repository-local Fluxzero manuals or duplicate the Fluxzero MCP configuration in this project.

--- a/flux-basic-java/CLAUDE.md
+++ b/flux-basic-java/CLAUDE.md
@@ -1,0 +1,12 @@
+@AGENTS.md
+
+## Claude Code bootstrap
+
+If the Fluxzero plugin is unavailable, run:
+
+```bash
+claude plugin marketplace add fluxzero-io/fluxzero-agent-integrations
+claude plugin install fluxzero@fluxzero
+```
+
+Then run `/reload-plugins` or start a new Claude Code session before continuing.

--- a/flux-basic-java/GEMINI.md
+++ b/flux-basic-java/GEMINI.md
@@ -1,0 +1,11 @@
+@./AGENTS.md
+
+## Gemini CLI bootstrap
+
+If the Fluxzero extension is unavailable, run this from a terminal outside the current interactive session:
+
+```bash
+gemini extensions install https://github.com/fluxzero-io/fluxzero-agent-integrations --consent
+```
+
+Then restart Gemini CLI before continuing.

--- a/flux-basic-kotlin/AGENTS.md
+++ b/flux-basic-kotlin/AGENTS.md
@@ -1,5 +1,7 @@
 # Fluxzero Agent Instructions
 
-Use the installed Fluxzero plugin for all Fluxzero application work in this project. Retrieve current SDK guidance
-through the plugin's Fluxzero MCP server; do not add or rely on repository-local Fluxzero manuals. If the plugin is not
-available, stop and ask the user to install it before changing Fluxzero code.
+Use the installed Fluxzero integration for all Fluxzero application work in this project. Retrieve current SDK guidance through its Fluxzero MCP server and follow the `build-fluxzero-app` skill.
+
+If that skill or MCP server is unavailable, install the Fluxzero integration for the coding agent you are currently running from `fluxzero-io/fluxzero-agent-integrations`. Installation changes agent startup configuration, so stop after installation and ask the user to reload the agent or start a new session before changing Fluxzero code.
+
+Use the integration as the single documentation source; do not add repository-local Fluxzero manuals or duplicate the Fluxzero MCP configuration in this project.

--- a/flux-basic-kotlin/CLAUDE.md
+++ b/flux-basic-kotlin/CLAUDE.md
@@ -1,0 +1,12 @@
+@AGENTS.md
+
+## Claude Code bootstrap
+
+If the Fluxzero plugin is unavailable, run:
+
+```bash
+claude plugin marketplace add fluxzero-io/fluxzero-agent-integrations
+claude plugin install fluxzero@fluxzero
+```
+
+Then run `/reload-plugins` or start a new Claude Code session before continuing.

--- a/flux-basic-kotlin/GEMINI.md
+++ b/flux-basic-kotlin/GEMINI.md
@@ -1,0 +1,11 @@
+@./AGENTS.md
+
+## Gemini CLI bootstrap
+
+If the Fluxzero extension is unavailable, run this from a terminal outside the current interactive session:
+
+```bash
+gemini extensions install https://github.com/fluxzero-io/fluxzero-agent-integrations --consent
+```
+
+Then restart Gemini CLI before continuing.


### PR DESCRIPTION
## Summary

- make `AGENTS.md` the shared Fluxzero integration bootstrap for Codex, Cursor, and GitHub Copilot
- add minimal `CLAUDE.md` and `GEMINI.md` import/bootstrap shims
- require byte-identical reviewed instructions in both Java and Kotlin templates
- extend CLI generation verification to cover all three instruction files

## Verification

- packaged both templates and verified all instruction files are included
- `./.github/scripts/verify-templates.sh flux-basic-java`
- `./.github/scripts/verify-templates.sh flux-basic-kotlin`

Both generated projects built successfully and remained free of repository-local Fluxzero manuals.