### PR TITLE
build(templates): align starters with SDK 1.230.0

### DIFF
--- a/flux-basic-java/build.gradle.kts
+++ b/flux-basic-java/build.gradle.kts
@@ -16,7 +16,7 @@ fluxzero {
     }
 }
 
-val fluxzeroVersion = "1.227.0"
+val fluxzeroVersion = "1.230.0"
 val fluxzeroIdpVersion = "0.15.0"
 val jettyVersion = "12.1.11"
 val lombokVersion = "1.18.46"

--- a/flux-basic-java/pom.xml
+++ b/flux-basic-java/pom.xml
@@ -21,7 +21,7 @@
 			<dependency>
 				<groupId>io.fluxzero</groupId>
 				<artifactId>fluxzero-bom</artifactId>
-				<version>1.227.0</version>
+				<version>1.230.0</version>
 				<scope>import</scope>
 				<type>pom</type>
 			</dependency>

--- a/flux-basic-kotlin/build.gradle.kts
+++ b/flux-basic-kotlin/build.gradle.kts
@@ -18,7 +18,7 @@ fluxzero {
     }
 }
 
-val fluxzeroVersion = "1.227.0"
+val fluxzeroVersion = "1.230.0"
 val fluxzeroIdpVersion = "0.15.0"
 
 repositories {

--- a/flux-basic-kotlin/pom.xml
+++ b/flux-basic-kotlin/pom.xml
@@ -16,7 +16,7 @@
         <kotlin-logging.version>7.0.14</kotlin-logging.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <fluxzero.version>1.227.0</fluxzero.version>
+        <fluxzero.version>1.230.0</fluxzero.version>
         <fluxzero-idp.version>0.15.0</fluxzero-idp.version>
     </properties>
 


### PR DESCRIPTION
## Summary

- align Java and Kotlin Maven starters with Fluxzero SDK 1.230.0
- align Java and Kotlin Gradle starters with the same SDK

## Why

The dashboard and Maven Central have moved to SDK 1.230.0. Keeping every starter on the same release prevents generated projects from immediately needing an SDK correction.

## Verification

- Java Maven tests
- Java Gradle tests
- Kotlin Maven tests
- Kotlin Gradle tests
- packaged release ZIP contains 1.230.0 in both language starters
